### PR TITLE
Fix aspect ratio for plotly

### DIFF
--- a/ifermi/plotter.py
+++ b/ifermi/plotter.py
@@ -61,6 +61,7 @@ _plotly_scene = dict(
         ticks="",
         showticklabels=False,
     ),
+    aspectmode='data',
 )
 
 _plotly_label_style = dict(


### PR DESCRIPTION
The aspect ratio of the axes for the 3D plotter was not fixed. This meant that if you resized the plotting window, the whole Fermi surface would change shape. This made it difficult to compare Fermi surfaces on Brillouin zones of different proportions (e.g. BZ with different sized z-axes looked the same because they were resized in the window).

I have fixed this for plotly plots only. The issue will still persist for matplotlib and vtk plotters.